### PR TITLE
【API】今月支払った人が正常に出力されていない問題を修正

### DIFF
--- a/api/get/paid-thismonth-member/handler.py
+++ b/api/get/paid-thismonth-member/handler.py
@@ -20,7 +20,7 @@ def items_query(house_name, begin_dt_str, end_dt_str):
     db_response = dynamodb_table.query(
         KeyConditionExpression=Key('House').eq(
             house_name) & Key('Timestamp').between(begin_dt_str, end_dt_str),
-        FilterExpression=Attr('Type').eq('Pay')
+        FilterExpression=Attr('Type').eq('Pay') & Attr('LiabilityMonth').begins_with(begin_dt_str)
     )
     return db_response['Items']
 


### PR DESCRIPTION
LiabilityMonth のフィルタを追加したことで、今月のCommonFee を支払った人のデータを出力している

close: #35 